### PR TITLE
Remove cookie and centralize token refresh

### DIFF
--- a/app/api/ApolloWrapper.tsx
+++ b/app/api/ApolloWrapper.tsx
@@ -98,8 +98,7 @@ if (!import.meta.env.VITE_JSCL_API_URL) {
 const httpLink = new HttpLink({
   // Tiene que ser una URL absoluta, ya que las URLs relativas no pueden ser usadas en SSR.
   uri: import.meta.env.VITE_JSCL_API_URL,
-  fetchOptions: { cache: "no-store", credentials: "include" },
-  credentials: "include",
+  fetchOptions: { cache: "no-store" },
 });
 
 function useMakeClient() {

--- a/app/api/ApolloWrapper.tsx
+++ b/app/api/ApolloWrapper.tsx
@@ -10,8 +10,7 @@ import { setContext } from "@apollo/client/link/context";
 import { onError } from "@apollo/client/link/error";
 import { RetryLink } from "@apollo/client/link/retry";
 
-import { useTokenRef } from "../utils/supabase/AuthProvider";
-import { useRefreshToken } from "../utils/supabase/client";
+import { useRefreshSession, useTokenRef } from "../utils/supabase/AuthProvider";
 
 const retryLink = new RetryLink();
 
@@ -62,21 +61,20 @@ const useAuthLink = () => {
 // Este link se encarga de manejar errores de autenticación
 // Si el servidor responde con un code UNAUTHENTICATED, intenta refrescar el token.
 const useErrorLink = () => {
-  const refreshToken = useRefreshToken();
+  const refreshSession = useRefreshSession();
 
   return onError(({ graphQLErrors, networkError, operation, forward }) => {
     if (graphQLErrors) {
       for (const err of graphQLErrors) {
         if (err.extensions.type === "UNAUTHENTICATED") {
-          refreshToken(
-            () => {
+          refreshSession()
+            .then(() => {
               forward(operation);
-            },
-            () => {
+            })
+            .catch(() => {
               // eslint-disable-next-line no-console
               console.error("Error refreshing access token");
-            },
-          );
+            });
         }
       }
     } else if (networkError) {

--- a/app/api/gql/graphql.ts
+++ b/app/api/gql/graphql.ts
@@ -633,7 +633,7 @@ export type TagSearchInput = {
 export type Ticket = {
   description: Maybe<Scalars["String"]["output"]>;
   endDateTime: Maybe<Scalars["DateTime"]["output"]>;
-  eventId: Scalars["String"]["output"];
+  event: Event;
   id: Scalars["ID"]["output"];
   /** Whether or not the ticket is free */
   isFree: Scalars["Boolean"]["output"];
@@ -773,6 +773,7 @@ export type UserTicket = {
   approvalStatus: TicketApprovalStatus;
   id: Scalars["ID"]["output"];
   paymentStatus: TicketPaymentStatus;
+  purchaseOrder: Maybe<PurchaseOrder>;
   redemptionStatus: TicketRedemptionStatus;
   ticketTemplate: Ticket;
 };

--- a/app/api/gql/schema.gql
+++ b/app/api/gql/schema.gql
@@ -620,7 +620,7 @@ Representation of a ticket
 type Ticket {
   description: String
   endDateTime: DateTime
-  eventId: String!
+  event: Event!
   id: ID!
 
   """
@@ -787,6 +787,7 @@ type UserTicket {
   approvalStatus: TicketApprovalStatus!
   id: ID!
   paymentStatus: TicketPaymentStatus!
+  purchaseOrder: PurchaseOrder
   redemptionStatus: TicketRedemptionStatus!
   ticketTemplate: Ticket!
 }

--- a/app/utils/supabase/AuthProvider/index.tsx
+++ b/app/utils/supabase/AuthProvider/index.tsx
@@ -1,5 +1,4 @@
-import { Session, User } from "@supabase/supabase-js";
-import cookies from "js-cookie";
+import { AuthSession, Session, User } from "@supabase/supabase-js";
 import {
   MutableRefObject,
   createContext,
@@ -11,11 +10,7 @@ import {
   useState,
 } from "react";
 
-import {
-  COOKIE_NAME,
-  getCookieOptions,
-  supabaseClient,
-} from "~/utils/supabase/client";
+import { supabaseClient } from "~/utils/supabase/client";
 
 export type AuthContextType = {
   user: User | null;
@@ -23,6 +18,7 @@ export type AuthContextType = {
   isReady: boolean;
   tokenRef: MutableRefObject<string | null>;
   setTokenRef: (token: string | null) => void;
+  refreshSession: () => Promise<void>;
 };
 
 export const AuthContext = createContext<AuthContextType>({
@@ -31,23 +27,31 @@ export const AuthContext = createContext<AuthContextType>({
   isReady: false,
   tokenRef: { current: null },
   setTokenRef: () => {},
+  refreshSession: async () => {},
 });
 
 export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
   const [supabaseSession, setSession] = useState<Session | null>(null);
   const [user, setUser] = useState<User | null>(null);
-  const [isReady, setIsReady] = useState(false);
   const tokenRef = useRef<string | null>(null);
 
-  const setTokenRef = useCallback((token: string | null) => {
-    tokenRef.current = token;
+  const setter = useCallback(
+    (session: AuthSession | null) => {
+      const user = session?.user ?? null;
+      const token = session?.access_token ?? null;
 
-    if (!tokenRef.current) {
-      cookies.remove(COOKIE_NAME);
-    } else {
-      cookies.set(COOKIE_NAME, tokenRef.current, getCookieOptions());
-    }
-  }, []);
+      setUser(user);
+      setSession(session);
+      tokenRef.current = token;
+    },
+    [setSession, setUser],
+  );
+  const setTokenRef = useCallback(
+    (token: string | null) => {
+      tokenRef.current = token;
+    },
+    [tokenRef],
+  );
 
   useEffect(() => {
     const initialize = async () => {
@@ -55,53 +59,47 @@ export const AuthProvider = ({ children }: { children: React.ReactNode }) => {
         data: { session },
       } = await supabaseClient.auth.getSession();
 
-      setSession(session);
+      setter(session);
+
       await supabaseClient.auth.startAutoRefresh();
     };
 
     const {
       data: { subscription },
     } = supabaseClient.auth.onAuthStateChange(async (_event, session) => {
-      setSession(session);
-      const token = session?.access_token ?? null;
-
-      tokenRef.current = token;
+      setter(session);
       await supabaseClient.auth.startAutoRefresh();
     });
 
     // eslint-disable-next-line no-console
-    initialize()
-      .catch(console.error)
-      .finally(() => setIsReady(true));
+    initialize().catch(console.error);
 
     return () => subscription.unsubscribe();
-  }, []);
+  }, [setter]);
 
-  useEffect(() => {
-    if (supabaseSession) {
-      const { user } = supabaseSession;
+  const refreshSession = useCallback(async () => {
+    const { data, error } = await supabaseClient.auth.refreshSession();
 
-      setUser(user);
+    if (error) {
+      // eslint-disable-next-line no-console
+      console.error("Error refreshing access token", error);
 
-      if (!tokenRef.current) {
-        cookies.remove(COOKIE_NAME);
-      } else {
-        cookies.set(COOKIE_NAME, tokenRef.current, getCookieOptions());
-      }
-    } else {
-      setUser(null);
+      return;
     }
-  }, [supabaseSession]);
 
+    setter(data?.session ?? null);
+  }, [setter]);
   const value = useMemo(
-    () => ({
-      user,
-      isLogged: Boolean(user?.id),
-      isReady,
-      tokenRef,
-      setTokenRef,
-    }),
-    [user, isReady, setTokenRef],
+    () =>
+      ({
+        user,
+        isLogged: Boolean(user?.id),
+        isReady: Boolean(supabaseSession),
+        tokenRef,
+        setTokenRef,
+        refreshSession,
+      }) satisfies AuthContextType,
+    [user, supabaseSession, tokenRef, setTokenRef, refreshSession],
   );
 
   return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
@@ -112,3 +110,4 @@ export const useTokenRef = () => useContext(AuthContext).tokenRef;
 export const useSetTokenRef = () => useContext(AuthContext).setTokenRef;
 export const useIsLoggedIn = () => useContext(AuthContext).isLogged;
 export const useIsAuthReady = () => useContext(AuthContext).isReady;
+export const useRefreshSession = () => useContext(AuthContext).refreshSession;

--- a/app/utils/supabase/client.ts
+++ b/app/utils/supabase/client.ts
@@ -1,11 +1,6 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import { createClient } from "@supabase/supabase-js";
-import cookies from "js-cookie";
 import { CookieAttributes } from "node_modules/@types/js-cookie";
-
-import { useSetTokenRef } from "~/utils/supabase/AuthProvider";
-
-export const COOKIE_NAME = "community-os-access-token";
 
 if (!import.meta.env.VITE_SUPABASE_URL) {
   throw new Error("Missing VITE_SUPABASE_URL");
@@ -20,44 +15,11 @@ export const supabaseClient = createClient(
   import.meta.env.VITE_SUPABASE_ANON_KEY,
 );
 
-export const useRefreshToken = () => {
-  const setToken = useSetTokenRef();
-
-  return (onSuccess?: () => void, onError?: (error: unknown) => void) => {
-    supabaseClient.auth
-      .refreshSession()
-      .then(({ data, error }) => {
-        if (error) {
-          // eslint-disable-next-line no-console
-          console.error("Error refreshing access token", error);
-
-          return;
-        }
-
-        const newToken = data.session?.access_token;
-
-        if (!newToken) {
-          // eslint-disable-next-line no-console
-          console.error("No access token found in session data");
-        } else {
-          setToken(newToken);
-        }
-
-        onSuccess?.();
-      })
-      .catch((error: unknown) => {
-        onError?.(error);
-      });
-  };
-};
-
 const oneHour = 1000 * 60 * 60;
 const oneYear = oneHour * 24 * 365;
 
 export const logout = async (onDone?: () => void) => {
   const data = await supabaseClient.auth.signOut({ scope: "local" });
-
-  cookies.remove(COOKIE_NAME);
 
   if (data.error) {
     throw new Error("Error logging out");


### PR DESCRIPTION
Making refresh token logic a bit more centralized and simple.
Removes the storing of cookies as we are not having SSR anymore. 