### PR TITLE
feat(PurchaseOrder): always return PublicTicketLink for simplicity

### DIFF
--- a/app/components/PurchaseOrder/Callback.tsx
+++ b/app/components/PurchaseOrder/Callback.tsx
@@ -161,12 +161,10 @@ export const PurchaseCallback = ({
   const publicURL =
     event?.publicShareURL &&
     purchaseOrder.status === PurchaseOrderStatusEnum.Complete
-      ? purchaseOrder.tickets.length > 1
-        ? urls.public.po(purchaseOrder.publicId as string, event.publicShareURL)
-        : urls.public.ticket(
-            purchaseOrder.tickets[0].publicId,
-            event.publicShareURL,
-          )
+      ? urls.public.ticket(
+          purchaseOrder.tickets[0].publicId,
+          event.publicShareURL,
+        )
       : null;
   const purchaseOrderStatuses = [
     PurchaseOrderStatusEnum.Open,


### PR DESCRIPTION
# Summary
- Instead of returning PO Public Link, return Ticket, for simplicity and no edge cases. 